### PR TITLE
update facilities and POPS table versions to 2019, capitalize group names

### DIFF
--- a/app/config/db_tables.js
+++ b/app/config/db_tables.js
@@ -14,8 +14,8 @@ const db_tables = {
   },
   facdb: {
     datasources: 'facdb_datasources_v2019_11',
-    facilities: 'facdb_v2019_11',
-    pops: 'pops_v201909',
+    facilities: 'facdb_v2019_12',
+    pops: 'pops_v201912_1',
   },
   housingdevdb: 'devdb_housing_pts_19v3',
   sca: 'sca_capital_projects_v2019',

--- a/app/config/totalcounts.json
+++ b/app/config/totalcounts.json
@@ -1,1 +1,1 @@
-{"cpMapped":5682,"cpAll":12042,"facilities":34216,"housing":56745,"housingRaw":66896,"cbbr":1271,"cpdbTotalCommitMin":-20000000,"cpdbTotalCommitMax":9300000000,"cpdbSpentToDateMax":2200000000}
+{"cpMapped":5682,"cpAll":12042,"facilities":33084,"housing":56745,"housingRaw":66896,"cbbr":1271,"cpdbTotalCommitMin":-20000000,"cpdbTotalCommitMax":9300000000,"cpdbSpentToDateMax":2200000000}


### PR DESCRIPTION
The trick was to branch off `staging` 