### PR TITLE
6066 Remove Authentication for Data Downloads

### DIFF
--- a/app/explorer/Download.jsx
+++ b/app/explorer/Download.jsx
@@ -26,11 +26,6 @@ class Download extends React.Component {
       noun: 'Developments',
       icon: 'cubes',
     },
-    'cb-budgetrequests': {
-      title: 'Budget Requests',
-      noun: 'Budget Requests',
-      icon: 'book',
-    },
     'facilities': {
       title: 'Facilities',
       noun: 'Facilities',
@@ -42,13 +37,12 @@ class Download extends React.Component {
     'capital-projects',
     // 'scaplan',
     'housing-development',
-    'cb-budgetrequests',
     'facilities',
   ];
 
   render() {
     const { counts, sql } = this.props;
-    const layers = this.props.isLoggedIn ? this.layers : ['facilities'];
+    const layers = this.layers;
 
     return (<div>
       {
@@ -70,19 +64,6 @@ class Download extends React.Component {
                   tableFiltered: counts.filtered['capital-projects-table'],
                   mapFiltered: counts.filtered['capital-projects'],
                 }}
-              />
-            }
-
-            { layerID === 'cb-budgetrequests' &&
-              <DownloadButtonBudgetRequests
-                layerID={'cb-budgetrequests'}
-                noun={this.layerMap['cb-budgetrequests'].noun}
-                sql={sql['cb-budgetrequests']}
-                counts={{
-                  total: counts.total['cb-budgetrequests'],
-                  filtered: counts.filtered['cb-budgetrequests'],
-                }}
-                filtered={counts.total['cb-budgetrequests'] !== counts.filtered['cb-budgetrequests']}
               />
             }
 

--- a/app/explorer/download/DownloadButtonCapitalProjects.jsx
+++ b/app/explorer/download/DownloadButtonCapitalProjects.jsx
@@ -29,7 +29,7 @@ class DownloadButton extends React.Component {
             >Project Level (csv)</MenuItem>
 
             <MenuItem
-              href={carto.completeDownloadUrlString(commitmentsSql, 'commitments', 'csv')}
+              href={carto.completeCommitmentsDownloadUrlString(commitmentsSql, 'commitments', 'csv')}
               onClick={this.logDownloadStat('capital-project_all', 'commitments')}
               eventKey="2"
             >

--- a/app/helpers/carto.js
+++ b/app/helpers/carto.js
@@ -21,6 +21,12 @@ export default {
     return this.generateUrlString(this.getCompleteSql(sql), fileType, `${filePrefix}_complete_${date}`);
   },
 
+  completeCommitmentsDownloadUrlString(sql, filePrefix, fileType) {
+    const date = moment().format('YYYY-MM-DD'); // eslint-disable-line no-undef
+    const sqlCommitments = 'SELECT * FROM '.concat(sql);
+    return this.generateUrlString(sqlCommitments, fileType, `${filePrefix}_complete_${date}`);
+  },
+
   filteredDownloadUrlString(sql, filePrefix, fileType) {
     const date = moment().format('YYYY-MM-DD'); // eslint-disable-line no-undef
     return this.generateUrlString(this.getFilteredSql(sql), fileType, `${filePrefix}_filtered_${date}`);


### PR DESCRIPTION
This PR fixes  #AB6066 and #AB6072.

It re-adds the old data files to be able to download without authentication;
Removes CBBR from that set of files that can be downloaded;
and fixes an issue with the SQL query for commitments that prevented downloading.