### PR TITLE
Task/may 2022 updates executive

### DIFF
--- a/app/config/db_tables.js
+++ b/app/config/db_tables.js
@@ -1,12 +1,12 @@
 const db_tables = {
   cpdb: {
-    budgets: "cpdb_budgets_22preliminary",
-    commitments: "cpdb_commitments_22preliminary",
-    projects: "cpdb_projects_22preliminary",
-    projects_combined: "cpdb_projects_combined_22preliminary",
-    adminbounds: "cpdb_adminbounds_22preliminary",
-    points: "cpdb_dcpattributes_pts_22preliminary",
-    polygons: "cpdb_dcpattributes_poly_22preliminary",
+    budgets: "cpdb_budgets_22executive",
+    commitments: "cpdb_commitments_22executive",
+    projects: "cpdb_projects_22executive",
+    projects_combined: "cpdb_projects_combined_22executive",
+    adminbounds: "cpdb_adminbounds_22executive",
+    points: "cpdb_dcpattributes_pts_22executive",
+    polygons: "cpdb_dcpattributes_poly_22executive",
   },
   cb_budget_requests: {
     points: "cbbr_fy22_pts",

--- a/app/config/totalcounts.json
+++ b/app/config/totalcounts.json
@@ -1,1 +1,1 @@
-{"cpMapped":4390,"cpAll":12294,"facilities":32311,"housing":0,"housingRaw":166086,"cbbr":1129,"cpdbTotalCommitMin":-80000000,"cpdbTotalCommitMax":5800000000,"cpdbSpentToDateMax":2600000000}
+{"cpMapped":5077,"cpAll":12772,"facilities":32311,"housing":0,"housingRaw":166086,"cbbr":1129,"cpdbTotalCommitMin":-80000000,"cpdbTotalCommitMax":5900000000,"cpdbSpentToDateMax":3400000000}

--- a/app/explorer/Search.jsx
+++ b/app/explorer/Search.jsx
@@ -1,19 +1,24 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import Autosuggest from 'react-autosuggest';
-import _ from 'lodash';
-import ga from '../helpers/ga';
+import React from "react";
+import PropTypes from "prop-types";
+import Autosuggest from "react-autosuggest";
+import _ from "lodash";
+import ga from "../helpers/ga";
 
 const streetName = (street) => {
-  if (street.match(/^(.*[a-z]{3})[a-z0-9]+$/i)) return street.toLowerCase().replace(/[^']\b\w/g, l => l.toUpperCase());
+  if (street.match(/^(.*[a-z]{3})[a-z0-9]+$/i))
+    return street.toLowerCase().replace(/[^']\b\w/g, (l) => l.toUpperCase());
   return street;
 };
 
-const addressString = s => `${streetName(s.properties.name)}, ${s.properties.borough}`;
+const addressString = (s) =>
+  `${streetName(s.properties.name)}, ${s.properties.borough}`;
 
 function renderSuggestion(s) {
   return (
-    <div><i className="fa fa-map-marker" aria-hidden="true" /><span>{addressString(s)}</span></div>
+    <div>
+      <i className="fa fa-map-marker" aria-hidden="true" />
+      <span>{addressString(s)}</span>
+    </div>
   );
 }
 
@@ -22,44 +27,45 @@ function shouldRenderSuggestions(value) {
 }
 
 class Search extends React.Component {
-
-  static displayName = 'Search';
+  static displayName = "Search";
 
   constructor(props) {
     super(props);
 
     this.state = {
-      value: '',
+      value: "",
       suggestions: [],
     };
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    return !_.isEqual(this.props, nextProps) ||
-           !_.isEqual(this.state, nextState);
+    return (
+      !_.isEqual(this.props, nextProps) || !_.isEqual(this.state, nextState)
+    );
   }
 
   onSuggestionsFetchRequested = ({ value }) => {
-    const apiCall = `https://geosearch.planninglabs.nyc/v2/autocomplete?text=${value}`;
+    const apiCall = `https://geosearch.planninglabs.nyc/v1/autocomplete?text=${value}`;
 
-    $.getJSON(apiCall, (data) => { // eslint-disable-line no-undef
+    $.getJSON(apiCall, (data) => {
+      // eslint-disable-line no-undef
       this.setState({
         suggestions: data.features,
       });
     });
-  }
+  };
 
   onSuggestionsClearRequested = () => {
     this.setState({
       suggestions: [],
     });
-  }
+  };
 
   onChange = (e, obj) => {
     this.setState({
       value: obj.newValue,
     });
-  }
+  };
 
   onSuggestionSelected = (e, o) => {
     this.setState({
@@ -67,36 +73,34 @@ class Search extends React.Component {
     });
 
     ga.event({
-      category: 'search',
-      action: 'search-term-selected',
+      category: "search",
+      action: "search-term-selected",
       label: o.suggestion.properties.name,
     });
 
     // pass up to Jane to create/update Marker
     this.props.onGeocoderSelection(o.suggestion, o.suggestion.properties.name);
-  }
+  };
 
-  clearInput= () => {
+  clearInput = () => {
     // tell Jane to hide Marker
     this.props.onClear();
 
     // set the input field to ''
     this.setState({
-      value: '',
+      value: "",
     });
-  }
+  };
 
   render() {
     const inputProps = {
-      placeholder: 'Search for an address',
+      placeholder: "Search for an address",
       value: this.state.value,
       onChange: this.onChange,
     };
 
     return (
-      <div
-        className={'search'}
-      >
+      <div className={"search"}>
         <Autosuggest
           suggestions={this.state.suggestions}
           onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
@@ -107,10 +111,15 @@ class Search extends React.Component {
           inputProps={inputProps}
           onSuggestionSelected={this.onSuggestionSelected}
         />
-        {this.props.selectionActive ?
-          <span className={'fa fa-times'} style={{ cursor: 'pointer' }} onClick={this.clearInput} /> :
-          <span className={'fa fa-search'} style={{ cursor: 'pointer' }} />
-        }
+        {this.props.selectionActive ? (
+          <span
+            className={"fa fa-times"}
+            style={{ cursor: "pointer" }}
+            onClick={this.clearInput}
+          />
+        ) : (
+          <span className={"fa fa-search"} style={{ cursor: "pointer" }} />
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

This PR updates `db_tables.js` to use the "executive" version of the new Carto tables and updates the files created by running `yarn generate-totalcounts`. It also switches `Search.jsx` back to using the Geosearch v1 endpoints because that work hasn't been QA'd yet but we need to do a release with this new data.