### PR TITLE
Switch Search.jsx back to Geosearch v2

### DIFF
--- a/app/explorer/Search.jsx
+++ b/app/explorer/Search.jsx
@@ -45,7 +45,7 @@ class Search extends React.Component {
   }
 
   onSuggestionsFetchRequested = ({ value }) => {
-    const apiCall = `https://geosearch.planninglabs.nyc/v1/autocomplete?text=${value}`;
+    const apiCall = `https://geosearch.planninglabs.nyc/v2/autocomplete?text=${value}`;
 
     $.getJSON(apiCall, (data) => {
       // eslint-disable-line no-undef


### PR DESCRIPTION
## Summary
Does just what it says on the tin, pointing the app back at Geosearch v2 for testing.