### PR TITLE
10042 – Allow commitment level data downloads

### DIFF
--- a/app/helpers/carto.js
+++ b/app/helpers/carto.js
@@ -23,8 +23,7 @@ export default {
 
   completeCommitmentsDownloadUrlString(sql, filePrefix, fileType) {
     const date = moment().format('YYYY-MM-DD'); // eslint-disable-line no-undef
-    const sqlCommitments = 'SELECT * FROM '.concat(sql);
-    return this.generateUrlString(sqlCommitments, fileType, `${filePrefix}_complete_${date}`);
+    return this.generateUrlString(sql, fileType, `${filePrefix}_complete_${date}`);
   },
 
   filteredDownloadUrlString(sql, filePrefix, fileType) {


### PR DESCRIPTION
A carto helper function was adding an extra "SELECT * FROM " to the beginning of the sql query, leading to an error and preventing users from downloading Commitment Level data.