### PR TITLE
Sort NTAs by value in filter dropdown

### DIFF
--- a/app/common/AreaFilterSelect.jsx
+++ b/app/common/AreaFilterSelect.jsx
@@ -29,12 +29,17 @@ class AreaFilterSelect extends React.Component {
     const polygonSelectorComponent = () => {
       if (this.state.selectedLayer !== null) {
         const placeholderName = `Select ${this.state.selectedLayer.label}`;
+        const sortedValues = this.props.filterDimensions[this.state.selectedLayer.value].values.sort((a,b) => {
+          if(a.value > b.value) return 1
+          if(a.value < b.value) return -1
+          return
+        })
         return (
           <MultiSelect
             placeholder={placeholderName}
             displayValues
             valueRenderer={option => option.label}
-            options={this.props.filterDimensions[this.state.selectedLayer.value].values}
+            options={sortedValues}
             onChange={this.handleMultiSelectChange.bind(this)}
           />
         );


### PR DESCRIPTION
Previously, NTAs were randomly displayed in the sidebar filter dropdown. This PR now sorts and displays them alphabetically by borocode, and then by number in ascending order.

Resolves AB[#10489](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/10489)

![Screen Shot 2022-09-14 at 9 44 31 AM](https://user-images.githubusercontent.com/43344288/190170966-41978ac3-ca88-4494-adbd-8c358c503f81.png)
