### PR TITLE
10599/10600 combined bug fixes for frequently used and custom maps

### DIFF
--- a/app/common/AreaFilterSelect.jsx
+++ b/app/common/AreaFilterSelect.jsx
@@ -47,9 +47,9 @@ class AreaFilterSelect extends React.Component {
       return null;
     };
 
-    const { exploreANeighborhoodSelected } = this.props;
+    const { exploreNeighborhoodSelected } = this.props;
 
-    if (exploreANeighborhoodSelected) {
+    if (exploreNeighborhoodSelected) {
       this.state.selectedLayer = { value: 'nta2020', label: 'Neighborhood Tabulation Area' };
 
       return (

--- a/app/jane-layers/facilities/filter-components/LayerSelector.jsx
+++ b/app/jane-layers/facilities/filter-components/LayerSelector.jsx
@@ -65,7 +65,7 @@ class LayerSelector extends React.Component {
     super(props);
     this.state = {
       expanded: null,
-      exploreANeighborhoodSelected: false,
+      exploreNeighborhoodSelected: false,
     };
   }
 
@@ -77,12 +77,26 @@ class LayerSelector extends React.Component {
       fetchSelectedFacilitiesCount,
     } = this.props;
 
-    if (this.props.locationState) {
-      this.state.exploreANeighborhoodSelected = true;
+    // handles NTA selections
+    if (this.props.locationState && this.props.locationState.adminboundaries) {
+      this.state.exploreNeighborhoodSelected = true;
     }
 
-    setFilters(filterDimensions);
-    fetchSelectedFacilitiesCount(filterDimensions);
+    // handles frequently used/custom map selections
+    if (locationState && locationState.filterDimensions) {
+      setFilters(locationState.filterDimensions);
+      fetchSelectedFacilitiesCount(locationState.filterDimensions);
+      return;
+    }
+
+    const mapsFilterDimensions = locationState && locationState.mergeFilterDimensions
+      ? Object.assign({}, filterDimensions, locationState.mergeFilterDimensions)
+      : filterDimensions;
+
+    const updatedFilterDimensions =  this.state.exploreNeighborhoodSelected ? filterDimensions : mapsFilterDimensions;
+
+    setFilters(updatedFilterDimensions);
+    fetchSelectedFacilitiesCount(updatedFilterDimensions);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -96,7 +110,7 @@ class LayerSelector extends React.Component {
   }
 
   updateFilterDimension = (dimension, values) => {
-    this.state.exploreANeighborhoodSelected = false;
+    this.state.exploreNeighborhoodSelected = false;
     this.props.setFilterDimension(dimension, values);
   };
 
@@ -146,7 +160,7 @@ class LayerSelector extends React.Component {
       admin_schooldistrict,
     } = filterDimensions;
 
-    const { exploreANeighborhoodSelected } = this.state;
+    const { exploreNeighborhoodSelected } = this.state;
 
     // override material ui ListItem spacing and react-select component font size
     const listItemStyle = {
@@ -184,7 +198,7 @@ class LayerSelector extends React.Component {
           >
             <AreaFilterSelect
               updateFilterDimension={this.updateFilterDimension}
-              exploreANeighborhoodSelected={this.state.exploreANeighborhoodSelected}
+              exploreNeighborhoodSelected={this.state.exploreNeighborhoodSelected}
               filterDimensions={{
                 cd,
                 nta2020,


### PR DESCRIPTION
#### This PR
Restored prev deleted functions in `LayerSelector.jsx` that were needed to generate the frequently used and custom map selections. I removed them in error in this [PR#76](https://github.com/NYCPlanning/labs-cp-platform/pull/76) believing the functions to be unused 🤦🏽 🤦🏽 🤦🏽.

#### Fixes
[ADO#10599](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/10599)
[ADO#10600](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/10600)