### PR TITLE
10526 – Updates SQL queries to match current Carto columns

### DIFF
--- a/app/helpers/sqlbuilder/SqlBuilder.js
+++ b/app/helpers/sqlbuilder/SqlBuilder.js
@@ -26,16 +26,12 @@ class SqlBuilder {
         const chunker = this[filter.type].bind(this);
         chunks.push(chunker(dimension, filters)); // pass the current dimension AND the entire filters object to each chunker
       }
-    });
-    
+    });    
     // build the final sql string
     const sqlTemplate = `SELECT ${this.columns} FROM ${this.tablename} WHERE `;
-    console.log('chunks', chunks) //eslint-disable-line
     // if there are no chunks, use 'WHERE TRUE' to select all
     const chunksString = chunks.length > 0 ? chunks.join(' AND ') : 'TRUE';
     const sql = sqlTemplate + chunksString;
-
-
 
     return sql;
   }

--- a/app/helpers/sqlbuilder/SqlBuilder.js
+++ b/app/helpers/sqlbuilder/SqlBuilder.js
@@ -27,12 +27,15 @@ class SqlBuilder {
         chunks.push(chunker(dimension, filters)); // pass the current dimension AND the entire filters object to each chunker
       }
     });
-
+    
     // build the final sql string
     const sqlTemplate = `SELECT ${this.columns} FROM ${this.tablename} WHERE `;
+    console.log('chunks', chunks) //eslint-disable-line
     // if there are no chunks, use 'WHERE TRUE' to select all
     const chunksString = chunks.length > 0 ? chunks.join(' AND ') : 'TRUE';
     const sql = sqlTemplate + chunksString;
+
+
 
     return sql;
   }
@@ -80,6 +83,10 @@ class SqlBuilder {
 
     if (subChunks.length > 0) { // don't set sqlChunks if nothing is selected
       const chunk = `(${subChunks.join(' OR ')})`;
+      // these changes to dimension are made to reflect the current columns on carto
+      if (dimension === 'cd') dimension = 'commboard';
+      if (dimension === 'nta2020') dimension = 'nta';
+      console.log('dimension', dimension) //eslint-disable-line
       return `${idColumn} IN (SELECT feature_id FROM ${lookupTable} WHERE admin_boundary_type = '${dimension}' AND ${chunk})`;
     }
 

--- a/app/helpers/sqlbuilder/SqlBuilder.js
+++ b/app/helpers/sqlbuilder/SqlBuilder.js
@@ -82,7 +82,6 @@ class SqlBuilder {
       // these changes to dimension are made to reflect the current columns on carto
       if (dimension === 'cd') dimension = 'commboard';
       if (dimension === 'nta2020') dimension = 'nta';
-      console.log('dimension', dimension) //eslint-disable-line
       return `${idColumn} IN (SELECT feature_id FROM ${lookupTable} WHERE admin_boundary_type = '${dimension}' AND ${chunk})`;
     }
 


### PR DESCRIPTION
Resolves AB[#10526](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20T?workitem=10526).

This PR updates the SQL queries when selecting a geo filter in the dropdown. The queries were referencing column names which have since been changed on Carto.

I decided to implement these changes as if statements directly in the SqlBuilder, instead of changing these labels across the entire application. My thinking is that it will make it just a bit easier to tweak or remove in the future if we find Carto columns changing again.

Community Districts
![Screen Shot 2022-09-20 at 10 57 52 AM](https://user-images.githubusercontent.com/43344288/191292775-e09cb84c-fe0e-436c-a3a3-df35daaf9939.png)

NTAs
![Screen Shot 2022-09-20 at 10 58 03 AM](https://user-images.githubusercontent.com/43344288/191292667-60ee495a-7bea-4f0d-bda0-54f21f1e8e45.png)
