### PR TITLE
Update to 22 adopted CPDB tables and regen total counts

### DIFF
--- a/app/config/db_tables.js
+++ b/app/config/db_tables.js
@@ -1,12 +1,12 @@
 const db_tables = {
   cpdb: {
-    budgets: "cpdb_budgets_22executive",
-    commitments: "cpdb_commitments_22executive",
-    projects: "cpdb_projects_22executive",
-    projects_combined: "cpdb_projects_combined_22executive",
-    adminbounds: "cpdb_adminbounds_22executive",
-    points: "cpdb_dcpattributes_pts_22executive",
-    polygons: "cpdb_dcpattributes_poly_22executive",
+    budgets: "cpdb_budgets_22adopted",
+    commitments: "cpdb_commitments_22adopted",
+    projects: "cpdb_projects_22adopted",
+    projects_combined: "cpdb_projects_combined_22adopted",
+    adminbounds: "cpdb_adminbounds_22adopted",
+    points: "cpdb_dcpattributes_pts_22adopted",
+    polygons: "cpdb_dcpattributes_poly_22adopted",
   },
   cb_budget_requests: {
     points: "cbbr_fy22_pts",

--- a/app/config/totalcounts.json
+++ b/app/config/totalcounts.json
@@ -1,1 +1,1 @@
-{"cpMapped":5077,"cpAll":12772,"facilities":32437,"housing":71836,"housingRaw":180937,"cbbr":1129,"cpdbTotalCommitMin":-80000000,"cpdbTotalCommitMax":5900000000,"cpdbSpentToDateMax":3400000000}
+{"cpMapped":4448,"cpAll":11551,"facilities":32437,"housing":71836,"housingRaw":180937,"cbbr":1129,"cpdbTotalCommitMin":-6000000,"cpdbTotalCommitMax":5200000000,"cpdbSpentToDateMax":3400000000}


### PR DESCRIPTION
### Summary

This PR just updates the app to use the new "22 Adopted" CPDB tables and regenerates the total count data.