### PR TITLE
11867 updating Source element id to match data source

### DIFF
--- a/app/jane-layers/adminboundaries/AdminBoundariesJaneLayer.jsx
+++ b/app/jane-layers/adminboundaries/AdminBoundariesJaneLayer.jsx
@@ -32,7 +32,7 @@ class AdminBoundariesJaneLayer extends React.Component {
     }
 
     return [
-      <Source id="nta" type="geojson" data="/data/ntaboundaries.geojson" />,
+      <Source id="nta2020" type="geojson" data="/data/ntaboundaries.geojson" />,
       <MapLayer id="ntaboundaries" source="nta2020" {...mapLayers.ntaboundaries} />,
       <MapLayer id="ntaboundaries_labels" source="nta2020" {...mapLayers.ntaboundaries_labels} />,
     ].map((child, index) => ({ ...child, key: index }));


### PR DESCRIPTION
##  Summary
In the layer selector, when selecting to filter by `Admin Boundaries` and then selecting `Neighborhood Tabulation Area`, the layer lines in the map were not drawn and no errors appeared in the browser console. By updating the `id` on the `Source` component, we then are able to see the NTA lines drawn as expected.


<img width="556" alt="Screen Shot 2023-01-31 at 3 14 52 PM" src="https://user-images.githubusercontent.com/11340947/215875333-05e21876-78ca-49b9-b529-e72db50f3a9d.png">
