### PR TITLE
12729 Clicks on Layer Toggles not being recorded in GA4 or FullStory

### DIFF
--- a/app/explorer/Explorer.jsx
+++ b/app/explorer/Explorer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import ReactGA4 from "react-ga4";
 import _ from 'lodash';
 import centroid from 'turf-centroid';
 
@@ -68,6 +69,15 @@ class Explorer extends React.Component {
   }
 
   onLayerToggle = (layerId, wasEnabled) => {
+    ReactGA4.gtag('event', 'toggle-layer', {
+      'action': `toggle-layer-${layerId}`,
+      'layer_view_value': !wasEnabled,
+    });
+    FS.event('capitalPlanningExplorerLayerToggle', {
+      layer_id: layerId,
+      layer_enabled: !wasEnabled
+    });
+
     const janeLayerIdsMap = {
       'housing-development': ['housing-development-points'],
       'capital-projects': [


### PR DESCRIPTION
Added GA4 and FullStory event tracking to when a user toggles a layer on or off.

Fixes [AB#12729](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/12729)