### PR TITLE
12819 New CPDB

### DIFF
--- a/app/config/db_tables.js
+++ b/app/config/db_tables.js
@@ -1,12 +1,12 @@
 const db_tables = {
   cpdb: {
-    budgets: "cpdb_budgets_22adopted",
-    commitments: "cpdb_commitments_22adopted",
-    projects: "cpdb_projects_22adopted",
-    projects_combined: "cpdb_projects_combined_22adopted",
-    adminbounds: "cpdb_adminbounds_22adopted",
-    points: "cpdb_dcpattributes_pts_22adopted",
-    polygons: "cpdb_dcpattributes_poly_22adopted",
+    budgets: "cpdb_budgets_23preliminary",
+    commitments: "cpdb_commitments_23preliminary",
+    projects: "cpdb_projects_23preliminary",
+    projects_combined: "cpdb_projects_combined_23preliminary",
+    adminbounds: "cpdb_adminbounds_23preliminary",
+    points: "cpdb_dcpattributes_pts_23preliminary",
+    polygons: "cpdb_dcpattributes_poly_23preliminary",
   },
   cb_budget_requests: {
     points: "cbbr_fy22_pts",

--- a/app/config/totalcounts.json
+++ b/app/config/totalcounts.json
@@ -1,1 +1,1 @@
-{"cpMapped":4448,"cpAll":11551,"facilities":32437,"housing":71836,"housingRaw":180937,"cbbr":1129,"cpdbTotalCommitMin":-6000000,"cpdbTotalCommitMax":5200000000,"cpdbSpentToDateMax":3400000000}
+{"cpMapped":4479,"cpAll":11984,"facilities":32437,"housing":71836,"housingRaw":180937,"cbbr":1129,"cpdbTotalCommitMin":-20000000,"cpdbTotalCommitMax":6900000000,"cpdbSpentToDateMax":3400000000}


### PR DESCRIPTION
Updated to use _23preliminary tables, and updated totalcounts.

Completes [AB#12819](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/12819)