### PR TITLE
13610 Update CPE to use correct Carto table for Zoning Districts

### DIFF
--- a/app/config/db_tables.js
+++ b/app/config/db_tables.js
@@ -31,7 +31,7 @@ const db_tables = {
     path_rail_routes: "path_rail_routes_v0",
     mta_bus_stops: "mta_bus_stops_v0",
     commerical_overlays: "commercial_overlays",
-    zoning_districts: "zoning_districts",
+    zoning_districts: "dcp_zoning_districts",
     bike_routes: "bike_routes",
   },
 };


### PR DESCRIPTION
Update table name from 'zoning_districts' to 'dcp_zoning_districts'.

Schema for the tables is the same, no other changes required.

Completes [AB#13610](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13610).