### PR TITLE
13712 Have Staging Branch use Staging Carto Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,5 @@ After pointing to a new table, run `yarn generate-totalcounts`. This script quer
 
 NOTE - New addition to the process beginning 2022-11-16:
 After running the script, please make sure that all of the values are correct by checking that when no filters are enabled, the UI shows `Showing all XXXXX records`, and not `XXXXX of YYYYY records`.  This should be true for each map (`/capitalprojects`, `/facilities`, and `housing`).
+
+To run a local instance which uses the staging server instead of production, add a .env file to the root directory with `CARTO_DOMAIN=dcpadmin.carto.com`

--- a/app/config/appConfig.js
+++ b/app/config/appConfig.js
@@ -2,7 +2,7 @@ const appConfig = {
   auth0_client_id: '3bulG9YPLTsoujIHvFg91w04HNIODCu1',
   auth0_domain: 'cpmanage.auth0.com',
   mapbox_accessToken: 'pk.eyJ1IjoiY2FwaXRhbHBsYW5uaW5nbnljIiwiYSI6ImNqODUwYmxyYzBnY3AycW9hOXA5NDE2eDQifQ.HYuWjTiwSoTu-QLWo0D76w',
-  carto_domain: 'planninglabs.carto.com',
+  carto_domain: process.env.CARTO_DOMAIN || 'planninglabs.carto.com',
   ga_tracking_code: 'UA-84250233-2',
   ga4_tracking_code: 'G-5JX3C0326L',
 };

--- a/example.env
+++ b/example.env
@@ -1,0 +1,2 @@
+# The following will use the staging instance of Carto instead of production
+CARTO_DOMAIN=dcpadmin.carto.com

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,6 +82,7 @@ module.exports = {
       'process.env': {
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
         DEV_TABLES: JSON.stringify(process.env.DEV_TABLES),
+        CARTO_DOMAIN: JSON.stringify(process.env.CARTO_DOMAIN),
       },
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
The tables that did not exist in the staging db were copied over from prod.

Code was changed to look for an environment variable for the host of the db, and default to production.

Environment variable was created in Netlify, as seen in screenshot below.  This branch is set to use the staging db to show that this implementation is working, that branch setting can be removed from Netlify once this has been merged.
<img width="1017" alt="image" src="https://github.com/NYCPlanning/labs-cp-platform/assets/61206501/5afe4e57-4efd-4656-9706-e99e74c39b95">



This closes [AB#13712](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13712)