### PR TITLE
13761 Match Colors to what is used in ZoLa

### DIFF
--- a/app/jane-layers/zoning/ZoningJaneLayer.jsx
+++ b/app/jane-layers/zoning/ZoningJaneLayer.jsx
@@ -82,7 +82,7 @@ class ZoningJaneLayer extends React.Component {
             ['C6', '#FDBDBB'],
             ['C7', '#FDBDBB'],
             ['C8', '#FDBDBB'],
-            ['M1', '#B7D6FD'],
+            ['M1', '#EDB7FD'],
             ['M2', '#EDB7FD'],
             ['M3', '#EDB7FD'],
             ['PA', '#E7FDDC'],


### PR DESCRIPTION
Changes M1 to this purple:
<img width="1986" alt="image" src="https://github.com/NYCPlanning/labs-cp-platform/assets/61206501/169ea205-c7b3-4678-8497-d16495036758">

To match the color in ZoLa:
<img width="1986" alt="image" src="https://github.com/NYCPlanning/labs-cp-platform/assets/61206501/971b3472-e4fe-4777-ac2f-aeb0887777b9">


Completes [AB#13761](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13761)