### PR TITLE
13609 Test new FacDB data in Capital Planning Explorer

### DIFF
--- a/app/facilities/LandingPage.jsx
+++ b/app/facilities/LandingPage.jsx
@@ -134,7 +134,7 @@ class FacilitiesLandingPage extends React.Component {
                                 'Hospitals and Clinics': null,
                                 'Mental Health': null,
                                 'Residential Health Care': null,
-                                'Chemical Dependency': null },
+                                'Substance Use Disorder Treatment Programs': null },
                               'Human Services': null,
                             },
                             'Education, Child Welfare, and Youth': {

--- a/app/facilities/config.js
+++ b/app/facilities/config.js
@@ -475,7 +475,7 @@ const getDefaultFilterDimensions = ({ selected, values }) => ({
       },
       {
         value: 'NYSOASAS',
-        label: 'NYS Office of Alcoholism and Substance Abuse Services',
+        label: 'NYS Office of Addiction Services and Supports',
       },
       {
         value: 'NYSOCFS',

--- a/app/facilities/defaultLayers.js
+++ b/app/facilities/defaultLayers.js
@@ -330,7 +330,7 @@ const defaultLayers = [
       {
         name: "Health Care",
         description:
-          "Health facilities overseen by NYC Health and Hospitals Corporation, NYC Health and Human Services, NYS Dept. of Health, NYS Office of Mental Health, and NYS Office of Alcoholism and Substance Abuse Services",
+          "Health facilities overseen by NYC Health and Hospitals Corporation, NYC Health and Human Services, NYS Dept. of Health, NYS Office of Mental Health, and NYS Office of Addiction Services and Supports",
         color: "#b67eb7",
         children: [
           {
@@ -348,7 +348,7 @@ const defaultLayers = [
             description: "Nursing homes, hospice care, and supportive housing",
           },
           {
-            name: "Chemical Dependency",
+            name: "Substance Use Disorder Treatment Programs",
             description:
               "Monitored support, inpatient, outpatient, and crisis services",
           },


### PR DESCRIPTION
Completes request in comments of [AB#13609](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13609)

Per Amanda, the following updates have been made to datasets formerly belonging to the Chemical Dependency sub-group within the Health and Human Services category of facilities:

- Update the agency name "NYS Office of Alcoholism and Substance Abuse Services" to "NYS Office of Addiction Services and Supports"
- Update the subgroup value "Chemical Dependency" to "Substance Use Disorder Treatment Programs"
- Change the "Operated by" value to the Provider name of the program

These are captured here : https://github.com/NYCPlanning/db-facilities/issues/597

Please review and update the UI accordingly to match. The data points themselves are currently missing from the staging map itself as well. I'm not sure if updating the names/paths will fix that issue as well. Once this is done, we have PO sign off to publish. Thanks!

![image](https://github.com/NYCPlanning/labs-cp-platform/assets/61206501/ed707733-d17e-4085-b46f-d770d9056cb7)


Updating with a local screenshot using staging db, as the deploy preview uses production, which does not yet include these changes.
<img width="2310" alt="image" src="https://github.com/NYCPlanning/labs-cp-platform/assets/61206501/04fca144-78e1-4646-93ce-154b5a601374">
