### PR TITLE
13888 New CPDB - 2023 Executive

### DIFF
--- a/app/config/db_tables.js
+++ b/app/config/db_tables.js
@@ -1,12 +1,12 @@
 const db_tables = {
   cpdb: {
-    budgets: "cpdb_budgets_23preliminary",
-    commitments: "cpdb_commitments_23preliminary",
-    projects: "cpdb_projects_23preliminary",
-    projects_combined: "cpdb_projects_combined_23preliminary",
-    adminbounds: "cpdb_adminbounds_23preliminary",
-    points: "cpdb_dcpattributes_pts_23preliminary",
-    polygons: "cpdb_dcpattributes_poly_23preliminary",
+    budgets: "cpdb_budgets_23executive",
+    commitments: "cpdb_commitments_23executive",
+    projects: "cpdb_projects_23executive",
+    projects_combined: "cpdb_projects_combined_23executive",
+    adminbounds: "cpdb_adminbounds_23executive",
+    points: "cpdb_dcpattributes_pts_23executive",
+    polygons: "cpdb_dcpattributes_poly_23executive",
   },
   cb_budget_requests: {
     points: "cbbr_fy22_pts",

--- a/app/config/totalcounts.json
+++ b/app/config/totalcounts.json
@@ -1,1 +1,1 @@
-{"cpMapped":4479,"cpAll":11984,"facilities":33429,"housing":71836,"housingRaw":180937,"cbbr":1129,"cpdbTotalCommitMin":-20000000,"cpdbTotalCommitMax":6900000000,"cpdbSpentToDateMax":3400000000}
+{"cpMapped":4611,"cpAll":12478,"facilities":33429,"housing":71836,"housingRaw":180937,"cbbr":1129,"cpdbTotalCommitMin":-20000000,"cpdbTotalCommitMax":6900000000,"cpdbSpentToDateMax":3400000000}


### PR DESCRIPTION
The 7 data tables that makeup CPDB are in [nycplanning-web.carto.com](https://gcc02.safelinks.protection.outlook.com/?url=https:%2f%2fnycplanning-web.carto.com%2f&data=05%7c01%7cADoyle%40planning.nyc.gov%7c8535a27875654033bec808dac10b939a%7c32f56fc75f814e22a95b15da66513bef%7c0%7c0%7c638034552723761790%7cUnknown%7cTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7c3000%7c%7c%7c&sdata=fsz56CEP4PjvZ0N%2BbUcnjD0UkAwo4ET9ooZyd6C1eNI%3D&reserved=0) and dcpadmin.carto.com, suffixed with "_23executive" and public with link.  Please work directly with Capital Planning.  Once these data are in the Capital Planning Explorer let Capital Planning know so that they can review and sign-off before publishing data to production Capital Planning Explorer.  Once the data are in the production Capital Planning Explorer please let EDM know.

This pr updates the table names.  It is working with the production db, but not with the staging db, as the tables in staging db are private.

Completes [AB#13888](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13888)