### PR TITLE
13889 New DevDB 22q4

### DIFF
--- a/app/config/db_tables.js
+++ b/app/config/db_tables.js
@@ -17,7 +17,7 @@ const db_tables = {
     facilities: "dcp_facilities",
     pops: "dcp_pops",
   },
-  housingdevdb: "devdb_housing_pts_22q2",
+  housingdevdb: "devdb_housing_pts_22q4",
   sca: "sca_capital_projects_v2019",
   support: {
     nta2020: "nta_boundaries",

--- a/app/config/totalcounts.json
+++ b/app/config/totalcounts.json
@@ -1,1 +1,1 @@
-{"cpMapped":4479,"cpAll":11984,"facilities":33429,"housing":71836,"housingRaw":180937,"cbbr":1129,"cpdbTotalCommitMin":-20000000,"cpdbTotalCommitMax":6900000000,"cpdbSpentToDateMax":3400000000}
+{"cpMapped":4479,"cpAll":11984,"facilities":33429,"housing":69691,"housingRaw":182504,"cbbr":1129,"cpdbTotalCommitMin":-20000000,"cpdbTotalCommitMax":6900000000,"cpdbSpentToDateMax":3400000000}


### PR DESCRIPTION
There is only one table with that string, "devdb_housing_pts_22q4", assuming that is the correct table to update, since the other task (13888) was to update the 7 tables for the cpdb.

This pr updates the table name. It is working with the production db, but not with the staging db, as the tables in staging db are private.

Completes [AB#13889](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13889)